### PR TITLE
Create Settings view model to better handle UI state changes and fix user switch crash

### DIFF
--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -84,8 +84,10 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.fragment:fragment-ktx:1.6.1'
     implementation project(path: ':shared')
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
     implementation 'androidx.activity:activity-compose:1.7.2'
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation 'androidx.preference:preference-ktx:1.2.0'

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <application
+        android:name=".PlexAAOS"
         android:allowBackup="true"
         android:appCategory="audio"
         android:icon="@mipmap/ic_launcher"

--- a/automotive/src/main/java/us/berkovitz/plexaaos/PinEntryDialogFragment.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/PinEntryDialogFragment.kt
@@ -2,70 +2,38 @@ package us.berkovitz.plexaaos
 
 import android.app.AlertDialog
 import android.app.Dialog
-import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
 import us.berkovitz.plexaaos.databinding.DialogPinEntryBinding
 
 class PinEntryDialogFragment : DialogFragment() {
-    interface PinEntryListener {
-        suspend fun onPinEntered(pin: String): String?
-        fun onPinCancelled()
-    }
-
-    private var listener: PinEntryListener? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        listener = parentFragment as? PinEntryListener ?: activity as? PinEntryListener
-    }
+    private val viewModel: SettingsViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val userTitle = arguments?.getString(ARG_USER_TITLE) ?: ""
-        val binding = DialogPinEntryBinding.inflate(LayoutInflater.from(context))
+        val userId = arguments?.getString(ARG_USER_ID) ?: ""
+        val binding = DialogPinEntryBinding.inflate(layoutInflater)
         val dialog = AlertDialog.Builder(requireContext())
             .setTitle(getString(R.string.pin_entry_title, userTitle))
             .setView(binding.root)
             .setPositiveButton(R.string.pin_entry_submit, null) // Set to null to override later
-            .setNegativeButton(R.string.pin_entry_cancel) { _, _ ->
-                listener?.onPinCancelled()
-            }
+            .setNegativeButton(R.string.pin_entry_cancel, null)
             .create()
 
         dialog.setOnShowListener {
             val submitButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+            val cancelButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
             
             val performSubmit = {
                 val pin = binding.pinEditText.text.toString()
-                if (pin.length != 4 || !pin.all { it.isDigit() }) {
-                    binding.errorTextView.text = getString(R.string.pin_error_digits)
-                    binding.errorTextView.visibility = View.VISIBLE
-                } else {
-                    lifecycleScope.launch {
-                        binding.errorTextView.visibility = View.GONE
-                        binding.progressBar.visibility = View.VISIBLE
-                        binding.pinEditText.isEnabled = false
-                        submitButton.isEnabled = false
-
-                        val error = listener?.onPinEntered(pin)
-
-                        if (error == null) {
-                            dialog.dismiss()
-                        } else {
-                            binding.errorTextView.text = error
-                            binding.errorTextView.visibility = View.VISIBLE
-                            binding.progressBar.visibility = View.GONE
-                            binding.pinEditText.text.clear()
-                            binding.pinEditText.isEnabled = true
-                            submitButton.isEnabled = true
-                        }
-                    }
-                }
+                viewModel.switchUser(userId, userTitle, pin) 
             }
 
             submitButton.setOnClickListener {
@@ -80,6 +48,38 @@ class PinEntryDialogFragment : DialogFragment() {
                     false
                 }
             }
+
+            // Observe view model state
+            lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    launch {
+                        viewModel.userSwitchStatus.collect { status ->
+                            // Block dialog interaction and show progress while user is switching
+                            val isSwitching = (status == UserSwitchStatus.Switching)
+                            isCancelable = !isSwitching
+                            dialog.setCanceledOnTouchOutside(!isSwitching)
+                            binding.pinEditText.isEnabled = !isSwitching
+                            submitButton.isEnabled = !isSwitching
+                            cancelButton.isEnabled = !isSwitching
+                            binding.progressBar.visibility = if (isSwitching) View.VISIBLE else View.GONE
+
+                            // Show error information if applicable
+                            if (status is UserSwitchStatus.Error) {
+                                binding.errorTextView.text = status.message
+                                binding.errorTextView.visibility = View.VISIBLE
+                                binding.pinEditText.text.clear()
+                            } else {
+                                binding.errorTextView.visibility = View.GONE
+                            }
+
+                            // Auto-dismiss dialog on success
+                            if (status is UserSwitchStatus.Success) {
+                                dialog.dismiss()
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         return dialog
@@ -87,10 +87,12 @@ class PinEntryDialogFragment : DialogFragment() {
 
     companion object {
         private const val ARG_USER_TITLE = "user_title"
+        private const val ARG_USER_ID = "user_id"
 
-        fun newInstance(userTitle: String): PinEntryDialogFragment {
+        fun newInstance(userId: String, userTitle: String): PinEntryDialogFragment {
             val fragment = PinEntryDialogFragment()
             val args = Bundle()
+            args.putString(ARG_USER_ID, userId)
             args.putString(ARG_USER_TITLE, userTitle)
             fragment.arguments = args
             return fragment

--- a/automotive/src/main/java/us/berkovitz/plexaaos/PlexAAOS.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/PlexAAOS.kt
@@ -1,0 +1,9 @@
+package us.berkovitz.plexaaos
+
+import android.app.Application
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+
+class PlexAAOS : Application() {
+    val applicationScope = CoroutineScope(SupervisorJob())
+}

--- a/automotive/src/main/java/us/berkovitz/plexaaos/SettingsActivity.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/SettingsActivity.kt
@@ -1,22 +1,12 @@
 package us.berkovitz.plexaaos
 
-import android.content.ComponentName
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import com.android.car.ui.core.CarUi
 import com.android.car.ui.toolbar.NavButtonMode
-import us.berkovitz.plexapi.myplex.MyPlexResource
-import us.berkovitz.plexapi.myplex.MyPlexUser
 
 class SettingsActivity : AppCompatActivity() {
-
-    lateinit var plexUtil: PlexUtil
-    private lateinit var musicServiceConnection: MusicServiceConnection
-    var plexToken: String? = null
-
-    var cachedServers: List<MyPlexResource>? = null
-    var cachedUsers: List<MyPlexUser>? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,14 +15,6 @@ class SettingsActivity : AppCompatActivity() {
         val toolbar = CarUi.requireToolbar(this)
         toolbar.setTitle(R.string.title_activity_settings)
         toolbar.navButtonMode = NavButtonMode.BACK
-
-        musicServiceConnection = MusicServiceConnection(
-            applicationContext,
-            ComponentName(applicationContext, PlexMediaService::class.java)
-        )
-
-        plexUtil = PlexUtil(this)
-        plexToken = plexUtil.getToken()
 
         if (savedInstanceState == null) {
             supportFragmentManager
@@ -48,14 +30,5 @@ class SettingsActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    fun signOut() {
-        musicServiceConnection.sendCommand(LOGOUT, Bundle.EMPTY)
-        finish()
-    }
-
-    fun notifyRefresh() {
-        musicServiceConnection.sendCommand(REFRESH, Bundle.EMPTY)
     }
 }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/SettingsFragment.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/SettingsFragment.kt
@@ -90,6 +90,10 @@ class SettingsFragment : PreferenceFragment() {
                             userPref?.entries = users.map { it.title }.toTypedArray()
                             userPref?.entryValues = users.map { it.id.toString() }.toTypedArray()
 
+                            // Make sure the current value of the preference is always null so that
+                            // switching consistently works. The list returned by the API only
+                            // contains users *other* than the current one.
+                            userPref?.value = null
                             when (status) {
                                 is UserSwitchStatus.Idle -> {
                                     userPref?.isEnabled = true

--- a/automotive/src/main/java/us/berkovitz/plexaaos/SettingsFragment.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/SettingsFragment.kt
@@ -3,31 +3,27 @@ package us.berkovitz.plexaaos
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import com.android.car.ui.preference.PreferenceFragment
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import us.berkovitz.plexapi.myplex.MyPlexResource
-import us.berkovitz.plexapi.myplex.MyPlexUser
 
-class SettingsFragment : PreferenceFragment(), PinEntryDialogFragment.PinEntryListener {
+class SettingsFragment : PreferenceFragment() {
+    private val viewModel: SettingsViewModel by activityViewModels()
+
     // Pending PIN dialog state
     private var pendingPinUserId: String? = null
     private var pendingPinUserTitle: String? = null
     private var showPendingPinDialog: Boolean = false
 
-    private var plexToken: String? = null
-    private lateinit var plexUtil: PlexUtil
-    private var users: List<MyPlexUser> = emptyList()
-
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.account_preferences, rootKey)
-
-        plexUtil = PlexUtil(requireContext())
-        plexToken = plexUtil.getToken()
 
         if (savedInstanceState != null) {
             pendingPinUserId = savedInstanceState.getString("pendingPinUserId")
@@ -48,6 +44,92 @@ class SettingsFragment : PreferenceFragment(), PinEntryDialogFragment.PinEntryLi
         setupServerPreference()
         setupUserPreference()
         setupSignOutPreference()
+
+        // Observe view model
+        val serverPref = findPreference<ListPreference>("pref_server")
+        val userPref = findPreference<ListPreference>("pref_switch_user")
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    combine(viewModel.servers, viewModel.currentServerId) { servers, currentId ->
+                        servers to currentId
+                    }.collect { (servers, currentId) ->
+                        if (servers == null) {
+                            serverPref?.isEnabled = false
+                            serverPref?.summary = getString(R.string.pref_loading)
+                        } else if (servers.isEmpty()) {
+                            serverPref?.isEnabled = false
+                            serverPref?.summary = getString(R.string.pref_server_none)
+                        } else {
+                            serverPref?.isEnabled = true
+
+                            val entries = mutableListOf(getString(R.string.pref_server_auto))
+                            entries.addAll(servers.map { it.name })
+                            serverPref?.entries = entries.toTypedArray()
+
+                            val entryValues = mutableListOf(SERVER_ID_AUTO)
+                            entryValues.addAll(servers.map { it.clientIdentifier ?: "" })
+                            serverPref?.entryValues = entryValues.toTypedArray()
+
+                            serverPref?.value = currentId ?: SERVER_ID_AUTO
+                            serverPref?.summary = getServerText(servers.find { it.clientIdentifier == currentId })
+                        }
+                    }
+                }
+                launch {
+                    combine(viewModel.users, viewModel.userSwitchStatus) { users, status ->
+                        users to status
+                    }.collect { (users, status) ->
+                        if (users == null) {
+                            userPref?.isEnabled = false
+                            userPref?.summary = getString(R.string.pref_loading)
+                        } else if (users.isEmpty()) {
+                            userPref?.isEnabled = false
+                            userPref?.summary = getString(R.string.pref_user_none)
+                        } else {
+                            userPref?.entries = users.map { it.title }.toTypedArray()
+                            userPref?.entryValues = users.map { it.id.toString() }.toTypedArray()
+
+                            when (status) {
+                                is UserSwitchStatus.Idle -> {
+                                    userPref?.isEnabled = true
+                                    userPref?.summary = getString(R.string.pref_user_summary)
+                                }
+                                is UserSwitchStatus.Switching -> {
+                                    userPref?.isEnabled = false
+                                    userPref?.summary = getString(R.string.user_switching)
+                                }
+                                is UserSwitchStatus.Success -> {
+                                    userPref?.isEnabled = true
+                                    val successString = getString(R.string.user_switch_success, status.userTitle)
+                                    userPref?.summary = successString
+                                    Toast.makeText(
+                                        requireContext(),
+                                        successString,
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                                is UserSwitchStatus.Error -> {
+                                    userPref?.isEnabled = true
+                                    val errorString = getString(R.string.user_switch_failed, status.message)
+                                    userPref?.summary = errorString
+                                    Toast.makeText(
+                                        requireContext(),
+                                        errorString,
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                            }
+                        }
+                    }
+                }
+                launch {
+                    viewModel.signOutEvent.collect {
+                        activity?.finish()
+                    }
+                }
+            }
+        }
     }
 
     override fun onResume() {
@@ -57,7 +139,7 @@ class SettingsFragment : PreferenceFragment(), PinEntryDialogFragment.PinEntryLi
         val userTitle = pendingPinUserTitle
         if (showPendingPinDialog && userId != null && userTitle != null) {
             showPendingPinDialog = false
-            val dialog = PinEntryDialogFragment.newInstance(userTitle)
+            val dialog = PinEntryDialogFragment.newInstance(userId, userTitle)
             dialog.show(childFragmentManager, "PinEntryDialog")
         }
     }
@@ -69,170 +151,50 @@ class SettingsFragment : PreferenceFragment(), PinEntryDialogFragment.PinEntryLi
 
     private fun setupServerPreference() {
         val serverPref = findPreference<ListPreference>("pref_server")
-        serverPref?.isSelectable = false
-        serverPref?.setOnPreferenceChangeListener { preference, newValue ->
-            onServerPreferenceChange(preference, newValue)
+        serverPref?.setOnPreferenceChangeListener { _, newValue ->
+            val serverId = newValue as? String ?: return@setOnPreferenceChangeListener true
+            viewModel.setServer(serverId)
+            true
         }
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            val settingsActivity = activity as? SettingsActivity
-            val servers = settingsActivity?.cachedServers ?: withContext(Dispatchers.IO) {
-                val fetched = PlexUtil.getServers(plexToken ?: "")
-                settingsActivity?.cachedServers = fetched
-                fetched
-            }
-
-            if (servers.isNotEmpty()) {
-                val entries = mutableListOf(getString(R.string.pref_server_auto))
-                val entryValues = mutableListOf("auto")
-
-                entries.addAll(servers.map { it.name })
-                entryValues.addAll(servers.map { it.clientIdentifier ?: "" })
-
-                serverPref?.entries = entries.toTypedArray()
-                serverPref?.entryValues = entryValues.toTypedArray()
-
-                val currentServer = withContext(Dispatchers.IO) {
-                    AndroidStorage.getServer(requireContext())
-                }
-                serverPref?.isEnabled = true
-                serverPref?.value = currentServer ?: "auto"
-                serverPref?.summary = getServerText(servers.find { it.clientIdentifier == currentServer })
-            } else {
-                serverPref?.isEnabled = false
-                serverPref?.summary = getString(R.string.pref_server_none)
-            }
-
-            serverPref?.isSelectable = true
-        }
-    }
-
-    private fun onServerPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-        if ((preference as ListPreference).value == newValue) {
-            return true
-        }
-
-        val serverId = newValue as? String ?: return true
-        val context = context?.applicationContext ?: return true
-        lifecycleScope.launch {
-            withContext(Dispatchers.IO) {
-                AndroidStorage.setServer(if (serverId == "auto") null else serverId, context)
-            }
-            (activity as? SettingsActivity)?.notifyRefresh()
-        }
-        return true
     }
 
     // User Preference
-    private fun getUserText(user: MyPlexUser?): String {
-        return user?.title ?: getString(R.string.pref_user_summary)
-    }
-
     private fun setupUserPreference() {
         val userPref = findPreference<ListPreference>("pref_switch_user")
-        userPref?.isSelectable = false
+        userPref?.setOnPreferenceClickListener {
+            viewModel.resetSwitchStatus()
+            false
+        }
         userPref?.setOnPreferenceChangeListener { preference, newValue ->
-            onUserPreferenceChange(preference, newValue)
-        }
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            val settingsActivity = activity as? SettingsActivity
-            users = settingsActivity?.cachedUsers ?: withContext(Dispatchers.IO) {
-                val fetched = PlexUtil.getUsers(plexToken ?: "")
-                settingsActivity?.cachedUsers = fetched
-                fetched
+            if ((preference as ListPreference).value == newValue) {
+                return@setOnPreferenceChangeListener true
             }
 
-            if (users.isNotEmpty()) {
-                val entries = users.map { it.title }.toTypedArray()
-                val entryValues = users.map { it.id.toString() }.toTypedArray()
-                userPref?.entries = entries
-                userPref?.entryValues = entryValues
-                userPref?.summary = getUserText(users.find { it.id.toString() == userPref.value })
+            val userId = newValue as? String ?: return@setOnPreferenceChangeListener true
+            val user = viewModel.users.value?.find { it.id.toString() == userId }
+
+            if (user?.protected == 1) {
+                // Set pending PIN dialog state
+                pendingPinUserId = userId
+                pendingPinUserTitle = user.title
+                showPendingPinDialog = true
             } else {
-                userPref?.isEnabled = false
-                userPref?.summary = getString(R.string.pref_user_none)
+                viewModel.switchUser(userId, user?.title ?: getString(R.string.unknown_user), null)
             }
 
-            userPref?.isSelectable = true
+            // Don't allow preference to update - there's no point in doing this as the user list
+            // will reload after a successful switch, and the user list only contains users
+            // *other* than the currently selected one.
+            false
         }
-    }
-
-    private suspend fun performUserSwitch(userId: String, userTitle: String, pin: String? = null): String? {
-        val context = requireContext().applicationContext
-        val activity = activity as? SettingsActivity
-        return try {
-            val newToken = withContext(Dispatchers.IO) {
-                PlexUtil.switchUser(plexToken ?: "", userId, pin)
-            }
-            plexUtil.setToken(newToken)
-
-            val userPref = findPreference<ListPreference>("pref_switch_user")
-            userPref?.value = userId
-            userPref?.summary = userTitle
-
-            activity?.notifyRefresh()
-            Toast.makeText(context, getString(R.string.user_switch_success, userTitle), Toast.LENGTH_SHORT).show()
-            null
-        } catch (e: Exception) {
-            val errorMessage = e.message ?: getString(R.string.unknown_error)
-            if (pin == null) {
-                Toast.makeText(context, getString(R.string.user_switch_failed, errorMessage), Toast.LENGTH_SHORT).show()
-            }
-            errorMessage
-        }
-    }
-
-    private fun onUserPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-        if ((preference as ListPreference).value == newValue) {
-            return true
-        }
-
-        val userId = newValue as? String ?: return true
-        val user = users.find { it.id.toString() == userId }
-
-        if (user?.protected == 1) {
-            // Set pending PIN dialog state
-            pendingPinUserId = userId
-            pendingPinUserTitle = user.title
-            showPendingPinDialog = true
-
-            // Don't allow preference to update, we will update it if user switch succeeds
-            return false 
-        } else {
-            lifecycleScope.launch {
-                performUserSwitch(userId, user?.title ?: getString(R.string.unknown_user))
-            }
-            return false
-        }
-    }
-
-    // PinEntryListener implementation
-    override suspend fun onPinEntered(pin: String): String? {
-        val userId = pendingPinUserId ?: ""
-        val userTitle = pendingPinUserTitle ?: getString(R.string.unknown_user)
-
-        val error = performUserSwitch(userId, userTitle, pin)
-
-        if (error == null) {
-            // Clear pending state
-            pendingPinUserId = null
-            pendingPinUserTitle = null
-        }
-        return error
-    }
-
-    override fun onPinCancelled() {
-        pendingPinUserId = null
-        pendingPinUserTitle = null
     }
 
     // Sign Out Preference
     private fun setupSignOutPreference() {
         val signOutPref = findPreference<Preference>("pref_sign_out")
-        signOutPref?.isEnabled = (plexToken != null)
+        signOutPref?.isEnabled = (viewModel.plexToken != null)
         signOutPref?.setOnPreferenceClickListener {
-            (activity as? SettingsActivity)?.signOut()
+            viewModel.signOut()
             true
         }
     }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/SettingsViewModel.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/SettingsViewModel.kt
@@ -1,0 +1,150 @@
+package us.berkovitz.plexaaos
+
+import android.app.Application
+import android.content.ComponentName
+import android.os.Bundle
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import us.berkovitz.plexapi.myplex.MyPlexResource
+import us.berkovitz.plexapi.myplex.MyPlexUser
+
+const val SERVER_ID_AUTO = "auto"
+
+sealed class UserSwitchStatus {
+    object Idle : UserSwitchStatus()
+    object Switching : UserSwitchStatus()
+    data class Success(val userTitle: String) : UserSwitchStatus()
+    data class Error(val message: String) : UserSwitchStatus()
+}
+
+class SettingsViewModel(application: Application) : AndroidViewModel(application) {
+    private val applicationScope = getApplication<PlexAAOS>().applicationScope
+    private val plexUtil = PlexUtil(application)
+    private val musicServiceConnection = MusicServiceConnection(
+        application,
+        ComponentName(application, PlexMediaService::class.java)
+    )
+    var plexToken = plexUtil.getToken()
+
+    private val _users = MutableStateFlow<List<MyPlexUser>?>(null)
+    val users: StateFlow<List<MyPlexUser>?> = _users.asStateFlow()
+
+    private val _servers = MutableStateFlow<List<MyPlexResource>?>(null)
+    val servers: StateFlow<List<MyPlexResource>?> = _servers.asStateFlow()
+
+    private val _currentServerId = MutableStateFlow<String?>(SERVER_ID_AUTO)
+    val currentServerId: StateFlow<String?> = _currentServerId.asStateFlow()
+
+    private val _userSwitchStatus = MutableStateFlow<UserSwitchStatus>(UserSwitchStatus.Idle)
+    val userSwitchStatus: StateFlow<UserSwitchStatus> = _userSwitchStatus.asStateFlow()
+
+    private val _signOutEvent = MutableSharedFlow<Unit>()
+    val signOutEvent: SharedFlow<Unit> = _signOutEvent.asSharedFlow()
+
+    init {
+        loadData()
+    }
+
+    private fun loadData() {
+        val token = plexToken ?: ""
+        viewModelScope.launch {
+            launch {
+                val savedServerId = withContext(Dispatchers.IO) {
+                    AndroidStorage.getServer(getApplication())
+                }
+                _currentServerId.value = savedServerId ?: SERVER_ID_AUTO
+            }
+            launch {
+                try {
+                    val fetchedServers = withContext(Dispatchers.IO) {
+                        PlexUtil.getServers(token)
+                    }
+                    _servers.value = fetchedServers
+                } catch (e: Exception) {
+                    _servers.value = emptyList()
+                }
+            }
+            launch {
+                try {
+                    val fetchedUsers = withContext(Dispatchers.IO) {
+                        PlexUtil.getUsers(token)
+                    }
+                    _users.value = fetchedUsers
+                } catch (e: Exception) {
+                    _users.value = emptyList()
+                }
+            }
+        }
+    }
+
+    fun setServer(serverId: String?) {
+        if (serverId == _currentServerId.value) return
+        val idToSave = if (serverId == SERVER_ID_AUTO) null else serverId
+        applicationScope.launch {
+            withContext(Dispatchers.IO) {
+                AndroidStorage.setServer(idToSave, getApplication())
+            }
+            _currentServerId.value = serverId ?: SERVER_ID_AUTO
+            withContext(Dispatchers.Main) {
+                notifyRefresh()
+            }
+        }
+    }
+
+    fun switchUser(userId: String, userTitle: String, pin: String?) {
+        val token = plexToken ?: return
+        _userSwitchStatus.value = UserSwitchStatus.Switching
+        applicationScope.launch {
+            try {
+                // Parameter validation
+                if (pin != null && (pin.length != 4 || !pin.all { it.isDigit() })) {
+                    _userSwitchStatus.value = UserSwitchStatus.Error(
+                        getApplication<Application>().getString(R.string.pin_error_digits))
+                    return@launch
+                }
+
+                val newToken = withContext(Dispatchers.IO) {
+                    PlexUtil.switchUser(token, userId, pin)
+                }
+                plexUtil.setToken(newToken)
+                plexToken = newToken
+
+                _userSwitchStatus.value = UserSwitchStatus.Success(userTitle)
+
+                // Reload data (users/servers) for the new user
+                loadData()
+                withContext(Dispatchers.Main) {
+                    notifyRefresh()
+                }
+            } catch (e: Exception) {
+                _userSwitchStatus.value = UserSwitchStatus.Error(
+                    e.message ?: getApplication<Application>().getString(R.string.unknown_error))
+            }
+        }
+    }
+
+    fun resetSwitchStatus() {
+        _userSwitchStatus.value = UserSwitchStatus.Idle
+    }
+
+    fun signOut() {
+        musicServiceConnection.sendCommand(LOGOUT, Bundle.EMPTY)
+        viewModelScope.launch {
+            _signOutEvent.emit(Unit)
+        }
+    }
+
+    private fun notifyRefresh() {
+        musicServiceConnection.sendCommand(REFRESH, Bundle.EMPTY)
+    }
+}

--- a/automotive/src/main/res/values/strings.xml
+++ b/automotive/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="pref_server_none">No servers found</string>
     <string name="pref_user_title">Switch User</string>
     <string name="pref_user_summary">Change the active Plex user</string>
+    <string name="pref_loading">Loading…</string>
     <string name="pref_user_none">No users found</string>
     <string name="pref_sign_out_title">Sign Out</string>
 
@@ -28,6 +29,7 @@
     <string name="pin_entry_cancel">Cancel</string>
     <string name="pin_entry_hint">PIN</string>
     <string name="pin_error_digits">PIN must be 4 digits</string>
+    <string name="user_switching">Switching user…</string>
     <string name="user_switch_success">Switched user to %1$s</string>
     <string name="user_switch_failed">Failed to switch user: %1$s</string>
     <string name="unknown_user">Unknown user</string>

--- a/automotive/src/main/res/xml/account_preferences.xml
+++ b/automotive/src/main/res/xml/account_preferences.xml
@@ -20,7 +20,8 @@
             android:title="@string/pref_user_title"
             android:summary="@string/pref_user_summary"
             android:entries="@array/empty_array"
-            android:entryValues="@array/empty_array" />
+            android:entryValues="@array/empty_array"
+            android:defaultValue="null" />
 
         <Preference
             android:key="pref_sign_out"


### PR DESCRIPTION
## Why is this change being made?
I went farther than I needed to go to fix the user switch crash, but I think this is a better long-term design for the Settings page due to the amount of UI state that was being manually managed before. Now the view model handles all Plex API calls and updates state flows that the UI listens to.

## What changed
- New SettingsViewModel: handles API calls and updates state flows that the UI listens to.
  - User/Server switch now run at application scope to avoid crashing (and complete the operation) even after the user exits the settings page while a switch is in flight
- SettingsActivity is simplified
- SettingsFragment now listens to view model state changes.
  - Status of user switch is now reflected via state changes, displaying "Switching user..." followed by "Switched user to Foo" or "Failed to switch user: Bar" based on success/failure in the preference summary
- PIN dialog now listens to view model state changes, and also fully prevents dismissal while user switch is happening