### PR TITLE
Add support for transcoding media with new user preferences

### DIFF
--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     implementation 'io.github.g0dkar:qrcode-kotlin-android:4.5.0'
 
     api "androidx.media3:media3-exoplayer:1.9.0"
+    implementation "androidx.media3:media3-exoplayer-dash:1.9.0"
     api "androidx.media3:media3-ui:1.9.0"
     implementation "androidx.media3:media3-session:1.9.0"
 

--- a/automotive/build.gradle
+++ b/automotive/build.gradle
@@ -104,7 +104,7 @@ dependencies {
 
     implementation 'androidx.media:media:1.7.1'
     implementation 'com.android.car.ui:car-ui-lib:2.6.0'
-    implementation 'us.berkovitz:kotlin-plexapi:0.1.18'
+    implementation 'us.berkovitz:kotlin-plexapi:0.1.19'
     implementation 'io.github.g0dkar:qrcode-kotlin-android:4.5.0'
 
     api "androidx.media3:media3-exoplayer:1.9.0"

--- a/automotive/src/main/java/us/berkovitz/plexaaos/AndroidStorage.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/AndroidStorage.kt
@@ -16,6 +16,11 @@ object AndroidStorage {
     private const val AUDIO_QUALITY = "audio_quality"
     private const val TRANSCODE_QUALITY = "transcode_quality"
 
+    fun getKeySync(key: String, context: Context): String? {
+        return context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
+            ?.getString(key, null)
+    }
+
     suspend fun getKey(key: String, context: Context): String? {
         return withContext(Dispatchers.IO) {
             return@withContext context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
@@ -85,12 +90,20 @@ object AndroidStorage {
         return getKey(AUDIO_QUALITY, context)?.toIntOrNull() ?: MAXIMUM_AUDIO_QUALITY
     }
 
+    fun getAudioQualitySync(context: Context): Int {
+        return getKeySync(AUDIO_QUALITY, context)?.toIntOrNull() ?: MAXIMUM_AUDIO_QUALITY
+    }
+
     suspend fun setAudioQuality(quality: Int, context: Context){
         return setKey(AUDIO_QUALITY, quality.toString(), context)
     }
 
     suspend fun getTranscodeQuality(context: Context): Int {
         return getKey(TRANSCODE_QUALITY, context)?.toIntOrNull() ?: DEFAULT_TRANSCODE_QUALITY
+    }
+
+    fun getTranscodeQualitySync(context: Context): Int {
+        return getKeySync(TRANSCODE_QUALITY, context)?.toIntOrNull() ?: DEFAULT_TRANSCODE_QUALITY
     }
 
     suspend fun setTranscodeQuality(quality: Int, context: Context){

--- a/automotive/src/main/java/us/berkovitz/plexaaos/AndroidStorage.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/AndroidStorage.kt
@@ -12,6 +12,8 @@ object AndroidStorage {
     private const val LAST_POSITION = "last_position"
     private const val SHUFFLE_ENABLED = "shuffle_enabled"
     private const val REPEAT_MODE = "repeat_mode"
+    private const val AUDIO_QUALITY = "audio_quality"
+    private const val TRANSCODE_QUALITY = "transcode_quality"
 
     suspend fun getKey(key: String, context: Context): String? {
         return withContext(Dispatchers.IO) {
@@ -78,4 +80,27 @@ object AndroidStorage {
         return setKey(SERVER, server, context)
     }
 
+    suspend fun getAudioQuality(context: Context): String? {
+        return getKey(AUDIO_QUALITY, context)
+    }
+
+    suspend fun setAudioQuality(quality: String?, context: Context){
+        if(quality == null){
+            removeKey(AUDIO_QUALITY, context)
+            return
+        }
+        return setKey(AUDIO_QUALITY, quality, context)
+    }
+
+    suspend fun getTranscodeQuality(context: Context): String? {
+        return getKey(TRANSCODE_QUALITY, context)
+    }
+
+    suspend fun setTranscodeQuality(quality: String?, context: Context){
+        if(quality == null){
+            removeKey(TRANSCODE_QUALITY, context)
+            return
+        }
+        return setKey(TRANSCODE_QUALITY, quality, context)
+    }
 }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/AndroidStorage.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/AndroidStorage.kt
@@ -1,11 +1,12 @@
 package us.berkovitz.plexaaos
 
 import android.content.Context
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 object AndroidStorage {
+    const val MAXIMUM_AUDIO_QUALITY = -1 // Maximum (never transcode)
+    const val DEFAULT_TRANSCODE_QUALITY = 128
     private const val SHARED_PREFS_NAME = "plexaaos"
     private const val SERVER = "server"
     private const val LAST_MEDIA_ID = "last_media_id"
@@ -80,27 +81,19 @@ object AndroidStorage {
         return setKey(SERVER, server, context)
     }
 
-    suspend fun getAudioQuality(context: Context): String? {
-        return getKey(AUDIO_QUALITY, context)
+    suspend fun getAudioQuality(context: Context): Int {
+        return getKey(AUDIO_QUALITY, context)?.toIntOrNull() ?: MAXIMUM_AUDIO_QUALITY
     }
 
-    suspend fun setAudioQuality(quality: String?, context: Context){
-        if(quality == null){
-            removeKey(AUDIO_QUALITY, context)
-            return
-        }
-        return setKey(AUDIO_QUALITY, quality, context)
+    suspend fun setAudioQuality(quality: Int, context: Context){
+        return setKey(AUDIO_QUALITY, quality.toString(), context)
     }
 
-    suspend fun getTranscodeQuality(context: Context): String? {
-        return getKey(TRANSCODE_QUALITY, context)
+    suspend fun getTranscodeQuality(context: Context): Int {
+        return getKey(TRANSCODE_QUALITY, context)?.toIntOrNull() ?: DEFAULT_TRANSCODE_QUALITY
     }
 
-    suspend fun setTranscodeQuality(quality: String?, context: Context){
-        if(quality == null){
-            removeKey(TRANSCODE_QUALITY, context)
-            return
-        }
-        return setKey(TRANSCODE_QUALITY, quality, context)
+    suspend fun setTranscodeQuality(quality: Int, context: Context){
+        return setKey(TRANSCODE_QUALITY, quality.toString(), context)
     }
 }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
@@ -6,7 +6,6 @@ import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Intent
 import android.os.Bundle
-import android.support.v4.media.MediaMetadataCompat
 import android.widget.Toast
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
@@ -27,7 +26,6 @@ import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.LoadControl
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadRequest
@@ -41,8 +39,6 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
-import androidx.media3.session.legacy.MediaSessionCompat
-import androidx.media3.session.legacy.PlaybackStateCompat
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -51,9 +47,7 @@ import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import us.berkovitz.plexaaos.extensions.id
 import us.berkovitz.plexaaos.library.BrowseTree
 import us.berkovitz.plexaaos.library.MusicSource
 import us.berkovitz.plexaaos.library.PlexSource
@@ -63,7 +57,6 @@ import us.berkovitz.plexaaos.library.buildMeta
 import us.berkovitz.plexapi.media.Track
 import us.berkovitz.plexapi.myplex.AuthorizationException
 import java.io.File
-import java.util.UUID
 import java.util.concurrent.Executors
 import kotlin.math.ceil
 import kotlin.math.min
@@ -270,6 +263,10 @@ class PlexMediaService : MediaLibraryService() {
         }
 
         logger.info("refreshCommand")
+        serviceScope.launch {
+            browseTree.audioQuality = AndroidStorage.getAudioQuality(applicationContext)
+            browseTree.transcodeQuality = AndroidStorage.getTranscodeQuality(applicationContext)
+        }
 
         // https://github.com/androidx/media/issues/561
         // notifySearchResultChanged is the magic answer to making media3 behave
@@ -516,7 +513,7 @@ class PlexMediaService : MediaLibraryService() {
                     if (item !is Track) {
                         return@forEach
                     }
-                    children += MediaItem.Builder().buildMeta(item, playlistId, pageNum?.toString())
+                    children += MediaItem.Builder().buildMeta(item, browseTree.audioQuality, browseTree.transcodeQuality, playlistId, pageNum?.toString())
                 }
                 logger.info("Sending playlist results: ${children.size} ${playlistId}")
                 future.set(children)
@@ -571,6 +568,10 @@ class PlexMediaService : MediaLibraryService() {
                 val repeatMode = AndroidStorage.getRepeatMode(applicationContext)
                 player.shuffleModeEnabled = shuffleMode
                 player.repeatMode = repeatMode
+
+                browseTree.audioQuality = AndroidStorage.getAudioQuality(applicationContext)
+                browseTree.transcodeQuality = AndroidStorage.getTranscodeQuality(applicationContext)
+
                 buildUI(session)
             }
 

--- a/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
@@ -166,8 +166,6 @@ class PlexMediaService : MediaLibraryService() {
         AndroidPlexApi.initPlexApi(this)
         plexUtil = PlexUtil(this)
 
-
-
         player = newPlayer()
         mediaLibrarySession = newLibrarySession()
 
@@ -263,10 +261,6 @@ class PlexMediaService : MediaLibraryService() {
         }
 
         logger.info("refreshCommand")
-        serviceScope.launch {
-            browseTree.audioQuality = AndroidStorage.getAudioQuality(applicationContext)
-            browseTree.transcodeQuality = AndroidStorage.getTranscodeQuality(applicationContext)
-        }
 
         // https://github.com/androidx/media/issues/561
         // notifySearchResultChanged is the magic answer to making media3 behave
@@ -568,9 +562,6 @@ class PlexMediaService : MediaLibraryService() {
                 val repeatMode = AndroidStorage.getRepeatMode(applicationContext)
                 player.shuffleModeEnabled = shuffleMode
                 player.repeatMode = repeatMode
-
-                browseTree.audioQuality = AndroidStorage.getAudioQuality(applicationContext)
-                browseTree.transcodeQuality = AndroidStorage.getTranscodeQuality(applicationContext)
 
                 buildUI(session)
             }
@@ -1018,6 +1009,32 @@ class PlexMediaService : MediaLibraryService() {
             ) {
                 message = "media not found";
             }
+
+            val mediaItem = player.currentMediaItem
+            if (mediaItem != null) {
+                val extras = mediaItem.mediaMetadata.extras
+                val transcodeUri = extras?.getString("TRANSCODE_URI")
+                val rawUri = extras?.getString("URI")
+                val currentUri = mediaItem.localConfiguration?.uri?.toString()
+
+                if (transcodeUri != null && rawUri != null && currentUri == transcodeUri) {
+                    logger.warn("Transcoding failed for ${currentUri}, falling back to raw stream at $rawUri")
+                    message = "transcoding failed"
+
+                    val newMediaItem = mediaItem.buildUpon()
+                        .setUri(rawUri)
+                        .build()
+
+                    val currentIndex = player.currentMediaItemIndex
+                    val playbackPosition = player.currentPosition
+
+                    player.replaceMediaItem(currentIndex, newMediaItem)
+                    player.seekTo(currentIndex, playbackPosition)
+                    player.prepare()
+                    player.play()
+                }
+            }
+
             Toast.makeText(
                 applicationContext,
                 message,

--- a/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
@@ -865,7 +865,8 @@ class PlexMediaService : MediaLibraryService() {
             val startIndex = items.indexOfFirst { it.mediaId == mediaItems[0].mediaId }
 
             // Prefetch next tracks using ExoPlayer's DownloadManager
-            prefetchNextTracks(5)
+            // TODO: See if prefetching can be re-enabled with transcoding
+            // prefetchNextTracks(5)
 
             return super.onSetMediaItems(
                 mediaSession,
@@ -992,7 +993,8 @@ class PlexMediaService : MediaLibraryService() {
             saveLastSong(mediaItem?.mediaId, 0)
 
             try {
-                prefetchNextTracks(5)
+                // TODO: See if prefetching can be re-enabled with transcoding
+                // prefetchNextTracks(5)
             } catch (t: Throwable) {
                 logger.error("prefetch failed: ${t.message}")
             }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
@@ -857,8 +857,7 @@ class PlexMediaService : MediaLibraryService() {
             val startIndex = items.indexOfFirst { it.mediaId == mediaItems[0].mediaId }
 
             // Prefetch next tracks using ExoPlayer's DownloadManager
-            // TODO: See if prefetching can be re-enabled with transcoding
-            // prefetchNextTracks(5)
+            prefetchNextTracks(5)
 
             return super.onSetMediaItems(
                 mediaSession,
@@ -912,6 +911,15 @@ class PlexMediaService : MediaLibraryService() {
                 val meta = player.getMediaItemAt(windowIndex)
                 val uri = meta.localConfiguration?.uri ?: continue
                 val id = meta.mediaId
+
+                // Only prefetch tracks that wouldn't be transcoded. The Plex Transcoding API
+                // only supports a single transcoding session per device.
+                val extras = meta.mediaMetadata.extras
+                val transcodeUri = extras?.getString("TRANSCODE_URI")
+                if (transcodeUri != null && uri.toString() == transcodeUri) {
+                    logger.warn("Skipping prefetch for transcoded track at index $windowIndex: $id")
+                    continue
+                }
 
                 try {
                     // Create download request for the track
@@ -985,8 +993,7 @@ class PlexMediaService : MediaLibraryService() {
             saveLastSong(mediaItem?.mediaId, 0)
 
             try {
-                // TODO: See if prefetching can be re-enabled with transcoding
-                // prefetchNextTracks(5)
+                prefetchNextTracks(5)
             } catch (t: Throwable) {
                 logger.error("prefetch failed: ${t.message}")
             }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/MediaService.kt
@@ -467,7 +467,7 @@ class PlexMediaService : MediaLibraryService() {
         }
 
         mediaSource.playlistWhenReady(playlistId) { plist ->
-            logger.error("plist when ready")
+            logger.debug("plist when ready")
             browseTree.storePlaylist(plist)
             if (plist != null && pageNum == null && plist.leafCount > PAGE_SIZE) {
                 val numPages = ceil(plist.leafCount.toDouble() / PAGE_SIZE).toInt()
@@ -562,7 +562,6 @@ class PlexMediaService : MediaLibraryService() {
                 val repeatMode = AndroidStorage.getRepeatMode(applicationContext)
                 player.shuffleModeEnabled = shuffleMode
                 player.repeatMode = repeatMode
-
                 buildUI(session)
             }
 

--- a/automotive/src/main/java/us/berkovitz/plexaaos/SettingsFragment.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/SettingsFragment.kt
@@ -41,6 +41,8 @@ class SettingsFragment : PreferenceFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupAudioQualityPreference()
+        setupTranscodeQualityPreference()
         setupServerPreference()
         setupUserPreference()
         setupSignOutPreference()
@@ -48,6 +50,8 @@ class SettingsFragment : PreferenceFragment() {
         // Observe view model
         val serverPref = findPreference<ListPreference>("pref_server")
         val userPref = findPreference<ListPreference>("pref_switch_user")
+        val audioPref = findPreference<ListPreference>("pref_audio_quality")
+        val transcodePref = findPreference<ListPreference>("pref_transcode_quality")
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
@@ -132,6 +136,16 @@ class SettingsFragment : PreferenceFragment() {
                         activity?.finish()
                     }
                 }
+                launch {
+                    viewModel.audioQuality.collect { quality ->
+                        audioPref?.value = quality.toString()
+                    }
+                }
+                launch {
+                    viewModel.transcodeQuality.collect { quality ->
+                        transcodePref?.value = quality.toString()
+                    }
+                }
             }
         }
     }
@@ -199,6 +213,26 @@ class SettingsFragment : PreferenceFragment() {
         signOutPref?.isEnabled = (viewModel.plexToken != null)
         signOutPref?.setOnPreferenceClickListener {
             viewModel.signOut()
+            true
+        }
+    }
+
+    private fun setupAudioQualityPreference() {
+        val audioPref = findPreference<ListPreference>("pref_audio_quality")
+        audioPref?.setOnPreferenceChangeListener { _, newValue ->
+            val qualityStr = newValue as? String ?: return@setOnPreferenceChangeListener true
+            val quality = qualityStr.toIntOrNull() ?: AndroidStorage.MAXIMUM_AUDIO_QUALITY
+            viewModel.setAudioQuality(quality)
+            true
+        }
+    }
+
+    private fun setupTranscodeQualityPreference() {
+        val transcodePref = findPreference<ListPreference>("pref_transcode_quality")
+        transcodePref?.setOnPreferenceChangeListener { _, newValue ->
+            val qualityStr = newValue as? String ?: return@setOnPreferenceChangeListener true
+            val quality = qualityStr.toIntOrNull() ?: AndroidStorage.DEFAULT_TRANSCODE_QUALITY
+            viewModel.setTranscodeQuality(quality)
             true
         }
     }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/SettingsViewModel.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/SettingsViewModel.kt
@@ -5,7 +5,6 @@ import android.content.ComponentName
 import android.os.Bundle
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,6 +44,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val _currentServerId = MutableStateFlow<String?>(SERVER_ID_AUTO)
     val currentServerId: StateFlow<String?> = _currentServerId.asStateFlow()
 
+    private val _audioQuality = MutableStateFlow<Int>(AndroidStorage.MAXIMUM_AUDIO_QUALITY)
+    val audioQuality: StateFlow<Int> = _audioQuality.asStateFlow()
+
+    private val _transcodeQuality = MutableStateFlow<Int>(AndroidStorage.DEFAULT_TRANSCODE_QUALITY)
+    val transcodeQuality: StateFlow<Int> = _transcodeQuality.asStateFlow()
+
     private val _userSwitchStatus = MutableStateFlow<UserSwitchStatus>(UserSwitchStatus.Idle)
     val userSwitchStatus: StateFlow<UserSwitchStatus> = _userSwitchStatus.asStateFlow()
 
@@ -63,6 +68,18 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                     AndroidStorage.getServer(getApplication())
                 }
                 _currentServerId.value = savedServerId ?: SERVER_ID_AUTO
+            }
+            launch {
+                val savedAudioQuality = withContext(Dispatchers.IO) {
+                    AndroidStorage.getAudioQuality(getApplication())
+                }
+                _audioQuality.value = savedAudioQuality
+            }
+            launch {
+                val savedTranscodeQuality = withContext(Dispatchers.IO) {
+                    AndroidStorage.getTranscodeQuality(getApplication())
+                }
+                _transcodeQuality.value = savedTranscodeQuality
             }
             launch {
                 try {
@@ -95,6 +112,32 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 AndroidStorage.setServer(idToSave, getApplication())
             }
             _currentServerId.value = serverId ?: SERVER_ID_AUTO
+            withContext(Dispatchers.Main) {
+                notifyRefresh()
+            }
+        }
+    }
+
+    fun setAudioQuality(quality: Int) {
+        if (quality == _audioQuality.value) return
+        applicationScope.launch {
+            withContext(Dispatchers.IO) {
+                AndroidStorage.setAudioQuality(quality, getApplication())
+            }
+            _audioQuality.value = quality
+            withContext(Dispatchers.Main) {
+                notifyRefresh()
+            }
+        }
+    }
+
+    fun setTranscodeQuality(quality: Int) {
+        if (quality == _transcodeQuality.value) return
+        applicationScope.launch {
+            withContext(Dispatchers.IO) {
+                AndroidStorage.setTranscodeQuality(quality, getApplication())
+            }
+            _transcodeQuality.value = quality
             withContext(Dispatchers.Main) {
                 notifyRefresh()
             }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
@@ -238,6 +238,10 @@ fun MediaItem.Builder.from(
         artistName = mediaItem.originalTitle
     }
 
+    // TODO: create new user settings for transcoding and honor them here
+    val isTranscodeEnabled = true
+    val transcodeBitrate = 320
+
     setMediaMetadata(MediaMetadata.Builder().apply {
         setTitle(mediaItem.title)
         setIsPlayable(true)
@@ -255,11 +259,15 @@ fun MediaItem.Builder.from(
         setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
         setExtras(Bundle().apply {
             this.putString("URI", mediaItem.getStreamUrl())
+            this.putString("TRANSCODE_URI", mediaItem.getTranscodeStreamUrl(transcodeBitrate))
         })
     }.build())
 
-    val uri = mediaItem.getStreamUrl().toUri()
-    setUri(uri)
+    if (isTranscodeEnabled && mediaItem.media?.first()?.bitrate!! > transcodeBitrate) {
+        setUri(mediaItem.getTranscodeStreamUrl(transcodeBitrate).toUri())
+    } else {
+        setUri(mediaItem.getStreamUrl().toUri())
+    }
 
     return this
 }

--- a/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
@@ -19,11 +19,10 @@ package us.berkovitz.plexaaos.library
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
-import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.MediaMetadataCompat
-import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import us.berkovitz.plexaaos.AndroidStorage
 import us.berkovitz.plexaaos.R
 import us.berkovitz.plexaaos.extensions.*
 import us.berkovitz.plexapi.media.Playlist
@@ -58,6 +57,8 @@ class BrowseTree(
     val recentMediaId: String? = null
 ) {
     private val mediaIdToChildren = mutableMapOf<String, MutableList<MediaItem>>()
+    var audioQuality: Int = AndroidStorage.MAXIMUM_AUDIO_QUALITY
+    var transcodeQuality: Int = AndroidStorage.DEFAULT_TRANSCODE_QUALITY
 
     companion object {
         val PAGE_SIZE = 100
@@ -121,7 +122,7 @@ class BrowseTree(
                 pageNum = idx.floorDiv(PAGE_SIZE).toString()
             }
 
-            playlistChildren += MediaItem.Builder().buildMeta(item, playlistId, pageNum)
+            playlistChildren += MediaItem.Builder().buildMeta(item, audioQuality, transcodeQuality, playlistId, pageNum)
         }
     }
 
@@ -202,6 +203,8 @@ fun MediaItem.Builder.from(playlist: Playlist): MediaItem.Builder {
 
 fun MediaItem.Builder.from(
     mediaItem: us.berkovitz.plexapi.media.MediaItem,
+    audioQuality: Int,
+    transcodeQuality: Int,
     playlistId: String? = null,
     pageNum: String? = null
 ): MediaItem.Builder {
@@ -238,9 +241,8 @@ fun MediaItem.Builder.from(
         artistName = mediaItem.originalTitle
     }
 
-    // TODO: create new user settings for transcoding and honor them here
-    val isTranscodeEnabled = true
-    val transcodeBitrate = 320
+    val mediaBitrate = mediaItem.media?.firstOrNull()?.bitrate ?: 0
+    val isTranscodeEnabled = audioQuality != AndroidStorage.MAXIMUM_AUDIO_QUALITY && mediaBitrate > audioQuality
 
     setMediaMetadata(MediaMetadata.Builder().apply {
         setTitle(mediaItem.title)
@@ -259,12 +261,12 @@ fun MediaItem.Builder.from(
         setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
         setExtras(Bundle().apply {
             this.putString("URI", mediaItem.getStreamUrl())
-            this.putString("TRANSCODE_URI", mediaItem.getTranscodeStreamUrl(transcodeBitrate))
+            this.putString("TRANSCODE_URI", mediaItem.getTranscodeStreamUrl(transcodeQuality))
         })
     }.build())
 
-    if (isTranscodeEnabled && mediaItem.media?.first()?.bitrate!! > transcodeBitrate) {
-        setUri(mediaItem.getTranscodeStreamUrl(transcodeBitrate).toUri())
+    if (isTranscodeEnabled) {
+        setUri(mediaItem.getTranscodeStreamUrl(transcodeQuality).toUri())
     } else {
         setUri(mediaItem.getStreamUrl().toUri())
     }
@@ -274,10 +276,12 @@ fun MediaItem.Builder.from(
 
 fun MediaItem.Builder.buildMeta(
     mediaItem: us.berkovitz.plexapi.media.MediaItem,
+    audioQuality: Int,
+    transcodeQuality: Int,
     playlistId: String? = null,
     pageNum: String? = null
 ): MediaItem {
-    return from(mediaItem, playlistId, pageNum).build()
+    return from(mediaItem, audioQuality, transcodeQuality, playlistId, pageNum).build()
 }
 
 

--- a/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
@@ -24,7 +24,6 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import us.berkovitz.plexaaos.AndroidStorage
 import us.berkovitz.plexaaos.R
-import us.berkovitz.plexaaos.extensions.*
 import us.berkovitz.plexapi.media.Playlist
 import us.berkovitz.plexapi.media.Track
 import androidx.core.net.toUri
@@ -244,7 +243,7 @@ fun MediaItem.Builder.from(
     }
 
     val mediaBitrate = mediaItem.media?.firstOrNull()?.bitrate ?: 0
-    val isTranscodeEnabled = audioQuality != AndroidStorage.MAXIMUM_AUDIO_QUALITY && mediaBitrate > audioQuality
+    val shouldTranscode = audioQuality != AndroidStorage.MAXIMUM_AUDIO_QUALITY && mediaBitrate > audioQuality
     var transcodeStreamUrl = mediaItem.getTranscodeStreamUrl(transcodeQuality)
 
     setMediaMetadata(MediaMetadata.Builder().apply {
@@ -268,7 +267,7 @@ fun MediaItem.Builder.from(
         })
     }.build())
 
-    if (isTranscodeEnabled) {
+    if (shouldTranscode) {
         setUri(transcodeStreamUrl.toUri())
     } else {
         setUri(mediaItem.getStreamUrl().toUri())

--- a/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
+++ b/automotive/src/main/java/us/berkovitz/plexaaos/library/BrowseTree.kt
@@ -57,8 +57,8 @@ class BrowseTree(
     val recentMediaId: String? = null
 ) {
     private val mediaIdToChildren = mutableMapOf<String, MutableList<MediaItem>>()
-    var audioQuality: Int = AndroidStorage.MAXIMUM_AUDIO_QUALITY
-    var transcodeQuality: Int = AndroidStorage.DEFAULT_TRANSCODE_QUALITY
+    var audioQuality: Int = AndroidStorage.getAudioQualitySync(context)
+    var transcodeQuality: Int = AndroidStorage.getTranscodeQualitySync(context)
 
     companion object {
         val PAGE_SIZE = 100
@@ -82,6 +82,8 @@ class BrowseTree(
     }
 
     fun reset() {
+        audioQuality = AndroidStorage.getAudioQualitySync(context)
+        transcodeQuality = AndroidStorage.getTranscodeQualitySync(context)
         mediaIdToChildren.clear()
         val rootList = mediaIdToChildren[UAMP_BROWSABLE_ROOT] ?: mutableListOf()
 
@@ -243,6 +245,7 @@ fun MediaItem.Builder.from(
 
     val mediaBitrate = mediaItem.media?.firstOrNull()?.bitrate ?: 0
     val isTranscodeEnabled = audioQuality != AndroidStorage.MAXIMUM_AUDIO_QUALITY && mediaBitrate > audioQuality
+    var transcodeStreamUrl = mediaItem.getTranscodeStreamUrl(transcodeQuality)
 
     setMediaMetadata(MediaMetadata.Builder().apply {
         setTitle(mediaItem.title)
@@ -261,12 +264,12 @@ fun MediaItem.Builder.from(
         setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
         setExtras(Bundle().apply {
             this.putString("URI", mediaItem.getStreamUrl())
-            this.putString("TRANSCODE_URI", mediaItem.getTranscodeStreamUrl(transcodeQuality))
+            this.putString("TRANSCODE_URI", transcodeStreamUrl)
         })
     }.build())
 
     if (isTranscodeEnabled) {
-        setUri(mediaItem.getTranscodeStreamUrl(transcodeQuality).toUri())
+        setUri(transcodeStreamUrl.toUri())
     } else {
         setUri(mediaItem.getStreamUrl().toUri())
     }

--- a/automotive/src/main/res/values/arrays.xml
+++ b/automotive/src/main/res/values/arrays.xml
@@ -1,4 +1,42 @@
 <resources>
+    <!-- Audio Quality Preference -->
+    <string-array name="audio_quality_entries">
+        <item>Maximum (never transcode)</item>
+        <item>320 kbps</item>
+        <item>256 kbps</item>
+        <item>192 kbps</item>
+        <item>160 kbps</item>
+        <item>128 kbps</item>
+    </string-array>
+
+    <string-array name="audio_quality_values">
+        <item>max</item>
+        <item>320</item>
+        <item>256</item>
+        <item>192</item>
+        <item>160</item>
+        <item>128</item>
+    </string-array>
+
+    <!-- Transcode Quality Preference -->
+    <string-array name="transcode_quality_entries">
+        <item>256 kbps</item>
+        <item>192 kbps</item>
+        <item>160 kbps</item>
+        <item>128 kbps</item>
+        <item>96 kbps</item>
+        <item>64 kbps</item>
+    </string-array>
+
+    <string-array name="transcode_quality_values">
+        <item>256</item>
+        <item>192</item>
+        <item>160</item>
+        <item>128</item>
+        <item>96</item>
+        <item>64</item>
+    </string-array>
+
     <!-- Reply Preference -->
     <string-array name="reply_entries">
         <item>Reply</item>

--- a/automotive/src/main/res/values/arrays.xml
+++ b/automotive/src/main/res/values/arrays.xml
@@ -10,7 +10,7 @@
     </string-array>
 
     <string-array name="audio_quality_values">
-        <item>max</item>
+        <item>-1</item>
         <item>320</item>
         <item>256</item>
         <item>192</item>
@@ -35,17 +35,6 @@
         <item>128</item>
         <item>96</item>
         <item>64</item>
-    </string-array>
-
-    <!-- Reply Preference -->
-    <string-array name="reply_entries">
-        <item>Reply</item>
-        <item>Reply to all</item>
-    </string-array>
-
-    <string-array name="reply_values">
-        <item>reply</item>
-        <item>reply_all</item>
     </string-array>
 
     <string-array name="empty_array">

--- a/automotive/src/main/res/values/strings.xml
+++ b/automotive/src/main/res/values/strings.xml
@@ -4,6 +4,13 @@
 
     <!-- Settings -->
     <string name="title_activity_settings">Settings</string>
+
+    <string name="playback_header">Playback</string>
+    <string name="audio_quality_title">Audio Quality</string>
+    <string name="audio_quality_summary">Music above this bitrate will be transcoded to reduce bandwidth usage</string>
+    <string name="transcode_quality_title">Transcode Quality</string>
+    <string name="transcode_quality_summary">Target bitrate when transcoding (Opus codec)</string>
+
     <string name="account_header">Account</string>
     <string name="pref_server_title">Server</string>
     <string name="pref_server_auto">Auto</string>

--- a/automotive/src/main/res/xml/account_preferences.xml
+++ b/automotive/src/main/res/xml/account_preferences.xml
@@ -13,7 +13,7 @@
             android:summary="Music above this bitrate will be transcoded to reduce bandwidth usage"
             android:entries="@array/audio_quality_entries"
             android:entryValues="@array/audio_quality_values"
-            android:defaultValue="max" />
+            android:defaultValue="-1" />
 
         <ListPreference
             android:key="pref_transcode_quality"

--- a/automotive/src/main/res/xml/account_preferences.xml
+++ b/automotive/src/main/res/xml/account_preferences.xml
@@ -5,20 +5,20 @@
     app:title="@string/title_activity_settings">
 
     <PreferenceCategory
-        android:title="Playback">
+        android:title="@string/playback_header">
 
         <ListPreference
             android:key="pref_audio_quality"
-            android:title="Audio Quality"
-            android:summary="Music above this bitrate will be transcoded to reduce bandwidth usage"
+            android:title="@string/audio_quality_title"
+            android:summary="@string/audio_quality_summary"
             android:entries="@array/audio_quality_entries"
             android:entryValues="@array/audio_quality_values"
             android:defaultValue="-1" />
 
         <ListPreference
             android:key="pref_transcode_quality"
-            android:title="Transcode Quality"
-            android:summary="Target bitrate when transcoding"
+            android:title="@string/transcode_quality_title"
+            android:summary="@string/transcode_quality_summary"
             android:entries="@array/transcode_quality_entries"
             android:entryValues="@array/transcode_quality_values"
             android:defaultValue="128" />

--- a/automotive/src/main/res/xml/account_preferences.xml
+++ b/automotive/src/main/res/xml/account_preferences.xml
@@ -5,6 +5,27 @@
     app:title="@string/title_activity_settings">
 
     <PreferenceCategory
+        android:title="Playback">
+
+        <ListPreference
+            android:key="pref_audio_quality"
+            android:title="Audio Quality"
+            android:summary="Music above this bitrate will be transcoded to reduce bandwidth usage"
+            android:entries="@array/audio_quality_entries"
+            android:entryValues="@array/audio_quality_values"
+            android:defaultValue="max" />
+
+        <ListPreference
+            android:key="pref_transcode_quality"
+            android:title="Transcode Quality"
+            android:summary="Target bitrate when transcoding"
+            android:entries="@array/transcode_quality_entries"
+            android:entryValues="@array/transcode_quality_values"
+            android:defaultValue="128" />
+        
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/account_header">
 
         <ListPreference


### PR DESCRIPTION
Adding support for automatic transcoding of media based on the item's bitrate to reduce bandwidth usage. Should complete #2 

- Added two new user preferences that act similarly to other clients:
  - "Audio Quality": the bitrate threshold above which music will be automatically transcoded. Defaults to Maximum as that is how it worked before.
  - "Transcode Quality": The bitrate to transcode media to using the Opus codec. Default is 128 kbps.
- MediaItem construction uses the quality preferences to automatically set the Uri of the item to either the transcode stream or raw stream URL. Both are saved into bundle extras so we fall back to the raw stream if the transcode hits an error. I know it was mentioned in #2 not to do this but this seems to work so I'm not sure we need the extra layer yet.
- Prefetching transcoded items breaks ongoing playback because Plex only seems to support a single transcoding session per device (this is not documented afaict). Updated prefetching logic to skip items that would be transcoded for now.